### PR TITLE
Adding redirect functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,17 @@ Crud.read('hello', function(req, res, next){
 
 The raw content to send is the first argument. It can be a Buffer or an Array or a String. `type` in the second argument is required. For the HTTP interface, this is used in the "Content-Type" header. For the Method and Publish interfaces, it is included in the response doc. `encoding` is optional, and describes the content encoding of the data if there is one. `filename` is optional. If it is specified, it is used in the Content-Disposition header for the HTTP interface, and is included in the response doc for the other interfaces. Set `disposition` to "inline" if you want your Content-Disposition header to be different to "attachment".
 
+If you want to redirect the user or return data which has the URL and the status code of the redirect you can use `res.redirect`,
+this function accepts two arguments `url` which is required & `status code` which is optional and by default it is 301.
+
+```javascript
+Crud.read('hello', function(req, res, next) {
+
+  res.redirect('http://example.com', 302);
+
+})
+```
+
 For more complicated scenarios the res object has `res.added`, `res.removed`, `res.changed`, `res.ready` and `res.onStop`. This is for when you want to respond with data from a reactive source, which can not be represented by a simple Mongo query. An example being, you want to observe how many documents are returned from a Mongo query without sending them all to the client. You *could* do this with a simple:
 
 ```javascript

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'centiq:crud',
-  version: '1.0.15',
+  version: '1.1.0',
   summary: 'Apply crud operations across meteor methods publications and http.',
   git: 'https://github.com/Centiq/meteor-crud',
   documentation: 'README.md'

--- a/server/crud.class.js
+++ b/server/crud.class.js
@@ -133,12 +133,24 @@ CRUD = class CRUD {
 		let toSend;
 		let onStop;
 		let sendResponse = false;
+		let redirect = false;
 
 		let filename, disposition;
 		let content_type = 'application/json';
 		let content_encoding;
 
 		let res = {
+			redirect: (url, code=301) => {
+
+			        res.send({
+				        url,
+				        code,
+			        });
+
+				redirect = true;
+				sendResponse = true;
+
+			},
 			sendBinary: (data, opt={}) => {
 
 				if (typeof data === 'string') {
@@ -253,6 +265,7 @@ CRUD = class CRUD {
 				sendResponse = false;
 				done(null, {
 					data: toSend,
+					redirect,
 					onStop,
 					filename,
 					disposition,

--- a/server/interfaces/meteor-publish.class.js
+++ b/server/interfaces/meteor-publish.class.js
@@ -58,9 +58,7 @@ MeteorPublishInterface = class MeteorPublishInterface extends BaseInterface {
 						 * we return a single object and its not a cursor so we wrap
 						 * it in an array so we can return the data.
 						 */
-						if (!Array.isArray(result.data)) {
-							result.data = [result.data];
-						}
+						result.data = [result.data];
 
 					}
 

--- a/server/interfaces/meteor-publish.class.js
+++ b/server/interfaces/meteor-publish.class.js
@@ -53,14 +53,15 @@ MeteorPublishInterface = class MeteorPublishInterface extends BaseInterface {
 
 						result.data._id = `${result.data.code}\0${result.data.url}`
 
-					}
+						/**
+						 * In a redirect,
+						 * we return a single object and its not a cursor so we wrap
+						 * it in an array so we can return the data.
+						 */
+						if (!Array.isArray(result.data)) {
+							result.data = [result.data];
+						}
 
-					/**
-					 * If we're returning a single object then
-					 * wrap it in an array.
-					 */
-					if (!Array.isArray(result.data)) {
-					        result.data = [result.data];
 					}
 
 					if (iface._transformers) {


### PR DESCRIPTION
This work is required for ms-app-tinyurl to redirect the user.

This PR aims to achieve adding redirects, by adding a new method
`sendRedirect` on to the res object. `sendRedirect` accepts
two arguments. `url` & `code` (which will default to 301).

When being called from the http interface the user will be redirected
to that location.

When being called using a meteor method the user will be returned an
object containing the url and the status code so the client can make the decision
about what to do.

When the endpoint is being subscribed to the user will also be returned
an object containing the url & and the status code.

An additional fix was applied to the publication interface to wrap
single objects in an array so that the information could be returned
to the client.